### PR TITLE
Render the output of stdout as that's what latex uses #4

### DIFF
--- a/rest_framework_latex/renderers.py
+++ b/rest_framework_latex/renderers.py
@@ -1,6 +1,6 @@
 import tempfile
 from os.path import join
-from subprocess import Popen
+from subprocess import Popen, PIPE
 import shutil
 import logging
 
@@ -70,11 +70,17 @@ class LatexRenderer(renderers.TemplateHTMLRenderer):
         # Latex it!
         call_args = [
             'lualatex', '-interaction=nonstopmode', tex_file]
-        proc = Popen(call_args, cwd=join(t_dir, 'tex'))
+        proc = Popen(
+            call_args, cwd=join(t_dir, 'tex'), stdout=PIPE, stderr=PIPE)
+
         out, err = proc.communicate()
+
         if proc.returncode != 0:
             err_msg = u'LaTeX returned nonzero response `{}` with msg: `{}`'
-            raise RuntimeError(err_msg.format(proc.returncode, err))
+
+            # Errors appear on stdout
+            raise RuntimeError(err_msg.format(proc.returncode, out))
+        logger.info(out)
         logger.info(err)
 
         # Read file

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='rest-framework-latex',
-    version='0.0.2',
+    version='0.0.3',
     description="A LaTeX renderer for Django REST Framework",
     author="SF Software limited t/a Pebble",
     author_email="sysadmin@mypebble.co.uk",

--- a/tests/tests/testrenderers/tests.py
+++ b/tests/tests/testrenderers/tests.py
@@ -52,7 +52,7 @@ class RendererTestCase(TestCase):
         settings.LATEX_RESOURCES = 'output'
 
         Popen.return_value = self._get_proc(
-            return_value=1, stderr='Test error')
+            return_value=1, stdout='Test error')
 
         try:
             self.renderer.render(


### PR DESCRIPTION
Get the actual output from stdout and stderr and send it into the exception properly.

We also use stdout to mirror `luatex` output using stdout and nothing in stderr.
