### PR TITLE
Modifiy LatexRenderer.render to wrap data into dict

### DIFF
--- a/rest_framework_latex/renderers.py
+++ b/rest_framework_latex/renderers.py
@@ -49,7 +49,7 @@ class LatexRenderer(renderers.TemplateHTMLRenderer):
         """
         # Get latex
         tex = super(LatexRenderer, self).render(
-            data, accepted_media_type, renderer_context)
+            {'data': data}, accepted_media_type, renderer_context)
 
         # Build tempoary directory
         t_dir = tempfile.mkdtemp(prefix='drf_latex_')


### PR DESCRIPTION
Fixes #20

This will make the data from the API view available as template variable `{{ data }}`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mypebble/rest-framework-latex/21)

<!-- Reviewable:end -->
